### PR TITLE
docs: refresh repository readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,53 @@
-## My personal repo
+# Mini Fighters
 
-This repo is a work in progress and is currently my personal thing. Feel free to fork or ask questions about it, but expect things to change drastically.
+Mini Fighters is an opinionated monorepo for building multiplayer-friendly browser games with a Svelte frontend and a Bun-powered backend. The project is currently under active development, but the tooling, folder layout, and conventions in this repository are already set up to help you ship experiments quickly and deploy them to modern hosting providers.
 
-## Information
+## Tech stack
 
-This is a highly opinionated monorepo for game dev using web tech.
+- **Frontend:** [Svelte](https://svelte.dev) + [Vite](https://vitejs.dev) with Tailwind CSS for styling.
+- **Backend:** [Bun](https://bun.sh) runtime hosting a websocket-ready API.
+- **Database:** [MongoDB](https://www.mongodb.com) for persistence.
+- **Deployment:** Ready for [Render](https://render.com) (backend) and [Vercel](https://vercel.com) (frontend).
 
-The stack is:
+## Repository layout
 
-- `Svelte` for frontend (https://svelte.dev)
-- `Bun` for backend (https://bun.sh)
-- `MongoDB` for database (https://www.mongodb.com)
+| Path | Description |
+| --- | --- |
+| `src/` | Main Svelte application, routes, stores, and styling helpers. |
+| `static/` | Static assets served by the frontend. |
+| `scripts/` | Utility scripts that support development and deployment. |
+| `svelte-game-server/` | Bun-based websocket server and supporting helpers. |
+| `svelte-game-engine/` | Shared engine code that powers core gameplay systems. |
 
-## Run the client locally
+## Prerequisites
 
-```
+- [Node.js](https://nodejs.org) 20 (run `nvm use` to match the `.nvmrc`).
+- [Bun](https://bun.sh) 1.x for running the realtime server.
+- Access to a MongoDB instance.
+- (Optional) Accounts on Render and Vercel if you plan to use the provided deployment pipelines.
+
+## Getting started
+
+### 1. Install dependencies (frontend)
+
+```bash
 nvm use
 npm install
+```
+
+### 2. Run the client locally
+
+```bash
 npm run dev
 ```
 
-## Run the server locally
+By default Vite serves the app on <http://localhost:5173>. The dev server will reload automatically as you edit files inside `src/`.
 
-`touch .env` and add:
+### 3. Configure environment for the server
 
-```
+Create a `.env` file in the repository root with values similar to the following:
+
+```dotenv
 PORT=1337
 CORS_ORIGIN=*
 NODE_ENV=development
@@ -33,27 +56,41 @@ SUPPORT_EMAIL_PASSWORD=<password>
 PASSWORD_RESET_HASH=<custom_hash>
 ```
 
-```
+### 4. Install dependencies and run the Bun server
+
+```bash
 cd svelte-game-server
-npm install
-npm run dev
+bun install  # or npm install
+bun run dev
 ```
+
+The server listens on the port specified in your `.env` file and exposes websocket-based APIs consumed by the Svelte client.
+
+## Available scripts
+
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Start the Vite development server. |
+| `npm run build` | Create a production build of the frontend. |
+| `npm run preview` | Preview the production build locally. |
+| `npm run check` | Run SvelteKit sync and type checks. |
+| `npm run lint` | Run Prettier in check mode and ESLint. |
+| `npm run format` | Apply formatting with Prettier. |
 
 ## Features
 
-- ✅ Socket server to handle any request (https://github.com/kkortes/async-await-websockets)
-- ✅ Account log in
-- ✅ Account creation
-- ✅ Account password recovery
-- ✅ Notification center
-- ✅ Render backend hosting setup (https://render.com)
-- ✅ Vercel frontend hosting setup (https://vercel.com)
-- ✅ Tailwind CSS for styling (https://tailwindcss.com)
+- ✅ Websocket server built on [`async-await-websockets`](https://github.com/kkortes/async-await-websockets) for realtime communication.
+- ✅ Account management: log in, sign up, and password recovery flows.
+- ✅ Notification center for surfacing game and account events.
+- ✅ Tailwind CSS utilities for rapid UI iteration.
+- ✅ Ready-to-use hosting blueprints for Render (backend) and Vercel (frontend).
 
-## Code base quirks
+## Development notes
 
-- Global styling is done like so: `:global(.anElement .anotherElement.anotherElement)`. It has to do with how Svelte is applying their automatic classes for scoping. It might be possible to skip the extra `.anotherElement` in the future. Skipping it now makes `development` and `production` run differentiating CSS.
+- Global styling often looks like `:global(.anElement .anotherElement.anotherElement)`. This pattern ensures consistent class scoping between development and production builds.
+- Environment files (`.env` for development and `.env.production` for production) are surfaced via `src/constants/ENV_VARS.js`, because directly referencing `import.meta.*` inside `.svelte` files can cause Vite to choke on embedded styles.
+- [`sveltekit-autoimport`](https://github.com/yuanchuan/sveltekit-autoimport) is configured in `vite.config.js`. Many imports inside `.svelte` and `.js` files are provided automatically, with commonly used store logic abstracted into `src/store` for easier consumption.
 
-- `.env (development) & .env.production (production)` are injected into `src/constants/ENV_VARS.js`. Trying to parse `import.meta.X` won't work in Svelte files, due to vite crashing when there is CSS in the files that they parse.
+## Contributing
 
-- This repo utilizes `sveltekit-autoimport` (https://github.com/yuanchuan/sveltekit-autoimport) hence some `.svelte` and `.js` imports seem to magically appear out of nowhere. See `vite.config.js` to see what's going on. For `const { someStoreProperty } = STORES` to work properly, a bunch of code has been abstracted into `/src/store` for ease of use.
+This is an evolving personal project. If you spot a bug or have ideas, feel free to open an issue or fork the repository and experiment.


### PR DESCRIPTION
## Summary
- replace the placeholder README with a project overview and setup instructions
- document the repo layout, tech stack, environment variables, and development scripts
- carry over key development notes to help contributors work with auto-imports and styling quirks

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68c959e25d6883309474a2e6013744da