### PR TITLE
Fix TypeScript errors and tighten typings

### DIFF
--- a/src/components/DevBar.svelte
+++ b/src/components/DevBar.svelte
@@ -5,9 +5,9 @@
 
   const healParty = () =>
     app.characters.forEach((character) => {
-      const { currentHealth, maxHealth } = calculateCombatStatsByCharacter(
-        CHARACTERS(character, true)
-      );
+      const combatStats = calculateCombatStatsByCharacter(CHARACTERS(character, true));
+      const maxHealth = combatStats.maxHealth ?? 0;
+      const currentHealth = combatStats.currentHealth ?? maxHealth;
       const heal = Math.ceil(maxHealth * 0.33);
       character.overrides.combatStats.currentHealth = Math.min(currentHealth + heal, maxHealth);
     });
@@ -44,7 +44,10 @@
   <crow vertical left class="gap-1 p-2">
     <Button
       onclick={() => {
-        app.characters[0].overrides.combatStats.currentHealth -= 10;
+        const character = app.characters[0];
+        if (!character) return;
+        const current = character.overrides.combatStats.currentHealth ?? 0;
+        character.overrides.combatStats.currentHealth = current - 10;
       }}
     >
       Deal 10 damage to char[0]

--- a/src/components/RefillHealthTimer.svelte
+++ b/src/components/RefillHealthTimer.svelte
@@ -39,9 +39,9 @@
 
     if (timeToRefill < 0) {
       app.characters.forEach((character) => {
-        const { currentHealth, maxHealth } = calculateCombatStatsByCharacter(
-          CHARACTERS(character, true)
-        );
+        const combatStats = calculateCombatStatsByCharacter(CHARACTERS(character, true));
+        const maxHealth = combatStats.maxHealth ?? 0;
+        const currentHealth = combatStats.currentHealth ?? maxHealth;
         const heal = Math.ceil(maxHealth * 0.33);
         character.overrides.combatStats.currentHealth = Math.min(currentHealth + heal, maxHealth);
       });

--- a/src/components/buttons/Clickable.svelte
+++ b/src/components/buttons/Clickable.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  let { children, class: classes, onclick, href } = $props<{ children: Snippet }>();
+  type ClickableProps = {
+    children: Snippet;
+    class?: string;
+    onclick?: (event: MouseEvent) => void;
+    href?: string;
+  };
+
+  const props = $props();
+
+  let { children, class: classes, onclick, href } = props as ClickableProps;
 </script>
 
 {#if href}

--- a/src/components/character/AbilitySelection.svelte
+++ b/src/components/character/AbilitySelection.svelte
@@ -9,7 +9,12 @@
   import ABILITIES from '$src/constants/ABILITIES';
   import type { Character } from '$src/types/character';
 
-  let { character, renderSides }: { character: Character; renderSides: boolean } = $props();
+  type AbilitySelectionProps = {
+    character: Character;
+    renderSides?: boolean;
+  };
+
+  let { character, renderSides = false }: AbilitySelectionProps = $props();
 
   let availableAbilities: AbilityRef[] = $state([]);
   let dropFromOthersDisabled = $state(false);
@@ -140,15 +145,17 @@
 
           return defaultAbility;
         })
-        .filter((a) => a),
+        .filter((a): a is Ability => Boolean(a)),
       ...defaultAbilities
     ] as Ability[];
 
     // Earlier .id instead of .uuid
-    if (
-      JSON.stringify(abs.map((a) => a?.uuid).sort((a, b) => a.localeCompare(b))) !==
-      JSON.stringify(character.abilities.map((a) => a.uuid).sort((a, b) => a.localeCompare(b)))
-    ) {
+    const nextAbilityIds = abs.map((a) => a.uuid ?? '').sort((a, b) => a.localeCompare(b));
+    const currentAbilityIds = character.abilities
+      .map((a) => a.uuid ?? '')
+      .sort((a, b) => a.localeCompare(b));
+
+    if (JSON.stringify(nextAbilityIds) !== JSON.stringify(currentAbilityIds)) {
       character.overrides.abilities = abs;
     }
   };

--- a/src/components/combat/CombatantAbilityBar.svelte
+++ b/src/components/combat/CombatantAbilityBar.svelte
@@ -1,9 +1,22 @@
 <script lang="ts">
-  let props = $props();
+  import type { Ability } from '$src/types/ability';
+  import type { StatusEffect, StatusStack } from '$src/types/combatant';
+
+  type CombatantAbilityBarProps = {
+    abilitiesCopied: Ability[];
+    progress?: number;
+    statuses?: {
+      isStunned: StatusEffect;
+      [key: string]: StatusEffect | StatusStack | number | boolean;
+    };
+    preview?: boolean;
+  };
+
+  let props: CombatantAbilityBarProps = $props();
 
   let preview = $derived(!!props.preview);
   let abilitiesCopied = $derived(props.abilitiesCopied);
-  let progress = $derived(props.progress);
+  let progress = $derived(props.progress ?? 0);
   let isStunned = $derived(!!props.statuses?.isStunned.ticks);
 </script>
 
@@ -53,7 +66,7 @@
       'grid -translate-x-[0.5px] translate-y-[0.5px] overflow-hidden rounded-b',
       preview && 'translate-x-0 translate-y-0 rounded-none'
     )}
-    style="width: calc((12px*{abilitiesCopied.reduce((acc, { ticks }) => acc + ticks, 0)}) + 2px);"
+    style="width: calc((12px*{abilitiesCopied.reduce((acc: number, { ticks }) => acc + ticks, 0)}) + 2px);"
   >
     {@render iconBar()}
     {#if progress}

--- a/src/components/form/Button.svelte
+++ b/src/components/form/Button.svelte
@@ -1,6 +1,20 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
+  type ButtonProps = {
+    primary?: boolean;
+    secondary?: boolean;
+    tertiary?: boolean;
+    blur?: boolean;
+    class?: string;
+    onclick?: (event: MouseEvent) => void;
+    children: Snippet;
+    disabled?: boolean;
+    type?: 'button' | 'submit' | 'reset';
+  };
+
+  const props = $props();
+
   let {
     primary = true,
     secondary = false,
@@ -9,8 +23,9 @@
     class: classes,
     onclick,
     children,
-    disabled = false
-  } = $props<{ children: Snippet }>();
+    disabled = false,
+    type = 'button'
+  } = props as ButtonProps;
 
   let inputRef: HTMLButtonElement;
 
@@ -31,6 +46,7 @@
     classes
   )}
   {disabled}
+  type={type}
 >
   {@render children()}
 </button>

--- a/src/components/global/ConnectSocket.svelte
+++ b/src/components/global/ConnectSocket.svelte
@@ -6,9 +6,13 @@
   const { WEBSOCKET_CONNECT } = ENV;
   const { notify } = ACTIONS;
 
+  type AsyncWebsocketWithEvents = AsyncAwaitWebsocket & {
+    on: (event: string, callback: (detail: any) => void) => void;
+  };
+
   $effect(() => {
     if (browser && !app.socket) {
-      const ws = aaw(WEBSOCKET_CONNECT) as AsyncAwaitWebsocket;
+      const ws = aaw(WEBSOCKET_CONNECT) as AsyncWebsocketWithEvents;
       ws.on('broadcast', console.info);
       ws.on('open', () => {
         app.socket = ws;

--- a/src/components/overlays/Combat.svelte
+++ b/src/components/overlays/Combat.svelte
@@ -12,6 +12,12 @@
     return { scale };
   };
 
+  type CombatOverlayProps = {
+    debug?: boolean;
+  };
+
+  let { debug: _debug = false }: CombatOverlayProps = $props();
+
   let startTeams: Team[] = $derived(app.combat.teamsStartState);
   let geometry = $derived(
     getGeometry(

--- a/src/components/tooltips/TooltipAbility.svelte
+++ b/src/components/tooltips/TooltipAbility.svelte
@@ -4,7 +4,9 @@
   import { AbilityType, type Ability } from '$src/types/ability';
   import type { Character } from '$src/types/character';
 
-  let props: Ability & { character: Character } = $derived(app.tooltip.props);
+  let props: Ability & { character: Character } = $derived(
+    app.tooltip!.props as Ability & { character: Character }
+  );
 
   let { name, ticks, type, description, chainLink, character, statusEffects } = $derived(props);
 
@@ -47,14 +49,14 @@
     {#if calculatedDamage?.result}
       <div class="text-sm">
         <strong class="text-black"> Damage: </strong>
-        {Math.ceil(combatStats?.damage * calculatedDamage.result)}
+        {Math.ceil((combatStats?.damage ?? 0) * calculatedDamage.result)}
         ({Math.ceil(calculatedDamage.result * 100)}% of total damage)
       </div>
     {/if}
     {#if calculatedHealing?.result}
       <div class="text-sm">
         <strong class="text-black"> Heal: </strong>
-        {Math.ceil(combatStats?.maxHealth * calculatedHealing.result)}
+        {Math.ceil((combatStats?.maxHealth ?? 0) * calculatedHealing.result)}
         <!-- ({calculatedHealing.baseDamage.toFixed(2) * 100}% + {calculatedHealing.addedDamage.toFixed(2) *
         100}% of damage) -->
         ({Math.ceil(calculatedHealing.result * 100)}% of max health)

--- a/src/components/tooltips/TooltipEquipment.svelte
+++ b/src/components/tooltips/TooltipEquipment.svelte
@@ -11,7 +11,9 @@
     combatStats,
     abilities,
     character
-  }: Equipment & { character: Character } = $derived(app.tooltip.props);
+  }: Equipment & { character: Character } = $derived(
+    app.tooltip!.props as Equipment & { character: Character }
+  );
 
   const prettyCombatStatKey = (key: string) =>
     ({

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -12,6 +12,7 @@ declare module 'lodash';
 declare module 'sveltekit-autoimport';
 declare module 'seedrandom';
 
+
 declare const tw: (typeof import('tailwind-merge'))['default'];
 declare const ACTIONS: (typeof import('$src/store/actions'))['default'];
 declare const STORES: (typeof import('$src/store/stores'))['default'];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,6 +34,9 @@
   let activePage = $derived($page.route.id?.split('/')[1] || 'start');
   let isDebugPage = $derived($page.route.id === '/debug');
   let characterIndex = $derived($page.params.characterIndex);
+  let selectedCharacterIndex = $derived(
+    characterIndex !== undefined ? parseInt(characterIndex, 10) : undefined
+  );
   let creatureId = $derived($page.params.creatureId);
 
   const { setOverlay } = ACTIONS;
@@ -41,7 +44,8 @@
 
   let showSequence = $state(false);
 
-  const selectBrawler = (e: Event, id: string) => {
+  const selectBrawler = (e: Event, id?: string) => {
+    if (!id) return;
     if (creatureId !== undefined && !app.selectedBrawlers.includes(id)) {
       e.preventDefault();
       app.selectedBrawlers = [id];
@@ -118,12 +122,12 @@
                   ABILITIES(ability, true)
                 )}
                 {@const isActive =
-                  parseInt(characterIndex, 10) === i ||
-                  (creatureId !== undefined && app.selectedBrawlers.includes(char.uuid))}
+                  selectedCharacterIndex === i ||
+                  (creatureId !== undefined &&
+                    (char.uuid ? app.selectedBrawlers.includes(char.uuid) : false))}
                 <Clickable
                   href="/brawlers/{i}"
                   class={tw('crow vertical w-full')}
-                  left
                   onclick={(e: Event) => selectBrawler(e, char.uuid)}
                 >
                   <crow

--- a/src/routes/scaling/+page.svelte
+++ b/src/routes/scaling/+page.svelte
@@ -26,7 +26,10 @@
 <Dropdown
   options={Object.keys(ALL_ABILITIES)}
   value={chosenAbility}
-  on:change={({ target: { value } }) => (chosenAbility = value)}
+  on:change={(event: Event) => {
+    const select = event.target as HTMLSelectElement;
+    chosenAbility = select.value;
+  }}
 />
 
 {#each abilitiesPool as abilities, i (i)}

--- a/src/ts/Combat.ts
+++ b/src/ts/Combat.ts
@@ -333,19 +333,26 @@ export const generateCombat = (seed: string, teams: Team[]) => {
             //     ability.end % target.abilitiesCopied[target.abilitiesCopied.length - 1].end! >
             //       now % target.abilitiesCopied[target.abilitiesCopied.length - 1].end!
             // );
-            const total = target.abilitiesCopied[target.abilitiesCopied.length - 1].end!;
+            const total = target.abilitiesCopied[target.abilitiesCopied.length - 1].end ?? 0;
             const t = ((now % total) + total) % total; // normalize now into [0,total)
 
-            const targetCurrentAbility = target.abilitiesCopied.find(
-              (ability) =>
-                ability.end % total > ability.start % total
-                  ? t >= ability.start % total && t < ability.end % total // normal segment
-                  : ability.end % total < ability.start % total
-                    ? t >= ability.start % total || t < ability.end % total // wraps over end->start
-                    : t === ability.start % total // zero-length segment
-            ) as Required<Ability>;
+            const targetCurrentAbility = target.abilitiesCopied.find((ability) => {
+              const abilityStart = ability.start ?? 0;
+              const abilityEnd = ability.end ?? 0;
 
-            const endTime = targetCurrentAbility.end % total;
+              return abilityEnd % total > abilityStart % total
+                ? t >= abilityStart % total && t < abilityEnd % total // normal segment
+                : abilityEnd % total < abilityStart % total
+                  ? t >= abilityStart % total || t < abilityEnd % total // wraps over end->start
+                  : t === abilityStart % total; // zero-length segment
+            });
+
+            if (!targetCurrentAbility) {
+              return;
+            }
+
+            const abilityEnd = targetCurrentAbility.end ?? 0;
+            const endTime = abilityEnd % total;
             const remainingTime =
               endTime > t
                 ? endTime - t // normal case

--- a/src/ts/equipment.ts
+++ b/src/ts/equipment.ts
@@ -1,5 +1,5 @@
 import { page } from '$app/stores';
-import type { EquipmentRef, EquipmentType, EquipmentSlot } from '$src/types/equipment';
+import type { Equipment, EquipmentRef, EquipmentType, EquipmentSlot } from '$src/types/equipment';
 import { get } from 'svelte/store';
 import app from '$src/app.svelte';
 import type { Character } from '$src/types/character';
@@ -37,9 +37,9 @@ export const equip = (equipmentRef: EquipmentRef, index: number) => {
   const character = CHARACTERS(characterRef, true);
   let slotsIn = decideEquipmentSlot(equipment.slotsIn, character);
   const slot = character.equipment[slotsIn];
-  const mainHand = character.equipment.mainHand
+  const mainHand: Equipment | null = character.equipment.mainHand
     ? EQUIPMENT(character.equipment.mainHand, true)
-    : {};
+    : null;
 
   // Remove item from inventory (equipment)
   app.inventory.splice(index, 1);

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -25,5 +25,5 @@ export type Character = CharacterRef & {
   equipment: CharacterEquipment;
   abilities: AbilityRef[];
   maxTicks: number;
-  combatStats?: CombatStats;
+  combatStats: CombatStats;
 };

--- a/src/types/combatStats.ts
+++ b/src/types/combatStats.ts
@@ -4,4 +4,9 @@ export type CombatStats = {
   damage?: number;
   maxArmor?: number;
   currentArmor?: number;
+  limits?: {
+    wounded: number;
+    concussed: number;
+    exposed: number;
+  };
 };

--- a/src/types/combatant.ts
+++ b/src/types/combatant.ts
@@ -3,25 +3,27 @@ import type { CombatStats } from '$src/types/combatStats';
 import type { Ability } from '$src/types/ability';
 import type { VFX } from '$src/types/vfx';
 
-type StatusStack = {
+export type StatusStack = {
   max: number;
   value: number;
 };
 
-type StatusEffect = {
+export type StatusEffect = {
   ticks: number;
   value: number;
 };
 
-export type Combatant = Character & {
+export type Combatant = Omit<Character, 'abilities' | 'combatStats'> & {
   id: string;
   teamIndex: number;
   animations: VFX[];
   injectedAnimations: VFX[];
   combatStats: Required<CombatStats>;
   eventTimestamp: number;
-  abilities: Required<Ability>[];
-  abilitiesCopied: Required<Ability>[];
+  eventAbility: string;
+  eventIndex: number;
+  abilities: Ability[];
+  abilitiesCopied: Ability[];
   damage: number;
   statuses: {
     isBlocking: boolean;

--- a/src/types/svelte-dnd-action.d.ts
+++ b/src/types/svelte-dnd-action.d.ts
@@ -1,0 +1,28 @@
+import type { ActionReturn } from 'svelte/action';
+
+declare module 'svelte-dnd-action' {
+  interface DndZoneAttributes<T = any> {
+    'on:consider'?: (event: CustomEvent<{ items: T[] }>) => void;
+    'on:finalize'?: (event: CustomEvent<{ items: T[] }>) => void;
+  }
+
+  interface Options<T = any> {
+    items: T[];
+    type?: string;
+    flipDurationMs?: number;
+    dropTargetStyle?: Record<string, string>;
+    dropTargetClasses?: string[];
+    dragDisabled?: boolean;
+    dropFromOthersDisabled?: boolean;
+    transformDraggedElement?: (node: HTMLElement, data: T, index: number) => void;
+    constrainAxisY?: boolean;
+    [key: string]: unknown;
+  }
+
+  export function dndzone<T = any>(
+    node: HTMLElement,
+    options: Options<T>
+  ): ActionReturn<Options<T>, DndZoneAttributes<T>>;
+
+  export function overrideItemIdKeyNameBeforeInitialisingDndZones(newKeyName: string): void;
+}


### PR DESCRIPTION
## Summary
- normalize combatant stat aggregation and ability hydration so prepareCombatant returns fully typed data without optional gaps
- type UI building blocks and ability displays to remove implicit any usage and support Svelte prop validation
- declare local svelte-dnd-action typings and tighten character/combatant interfaces to satisfy downstream consumers and pages

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68c962c9c3e08330bcf354198a2ddf3a